### PR TITLE
Improve error handling

### DIFF
--- a/src/server/Server.js
+++ b/src/server/Server.js
@@ -56,6 +56,10 @@ class Server {
   }
 
   setupErrorHandler() {
+    this.app.use((req, res) => {
+      res.status(404).json({ message: 'No route matches' });
+    });
+
     // eslint-disable-next-line no-unused-vars
     this.app.use((err, req, res, next) => {
       console.error(err.stack);

--- a/src/server/api/currentUser.js
+++ b/src/server/api/currentUser.js
@@ -1,10 +1,6 @@
 const axios = require('../axios');
 
 module.exports = {
-  create: {
-    path: '/current_user',
-    handler: async (req, res) => res.status(403).json({})
-  },
   read: {
     path: '/current_user',
     handler: async (req, res) => {
@@ -15,13 +11,5 @@ module.exports = {
 
       res.status(200).json(currentUser.data);
     }
-  },
-  update: {
-    path: '/current_user',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/current_user',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/currentUser.js
+++ b/src/server/api/currentUser.js
@@ -9,16 +9,11 @@ module.exports = {
     path: '/current_user',
     handler: async (req, res) => {
       const { headers } = req;
+      const currentUser = await axios.get('/current_user', {
+        headers
+      });
 
-      try {
-        const currentUser = await axios.get('/current_user', {
-          headers
-        });
-
-        res.status(200).json(currentUser.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(currentUser.data);
     }
   },
   update: {

--- a/src/server/api/currentUserGroups.js
+++ b/src/server/api/currentUserGroups.js
@@ -9,16 +9,11 @@ module.exports = {
     path: '/current_user/groups',
     handler: async (req, res) => {
       const { headers } = req;
+      const currentUserGroups = await axios.get(`/current_user/groups`, {
+        headers
+      });
 
-      try {
-        const currentUserGroups = await axios.get(`/current_user/groups`, {
-          headers
-        });
-
-        res.status(200).json(currentUserGroups.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(currentUserGroups.data);
     }
   },
   update: {

--- a/src/server/api/currentUserGroups.js
+++ b/src/server/api/currentUserGroups.js
@@ -3,7 +3,7 @@ const axios = require('../axios');
 module.exports = {
   create: {
     path: '/current_user/groups',
-    handler: async (req, res) => res.status(403).json({})
+    handler: async (req, res) => res.status(404).json({})
   },
   read: {
     path: '/current_user/groups',
@@ -15,13 +15,5 @@ module.exports = {
 
       res.status(200).json(currentUserGroups.data);
     }
-  },
-  update: {
-    path: '/current_user/groups',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/current_user/groups',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/events.js
+++ b/src/server/api/events.js
@@ -6,24 +6,19 @@ module.exports = {
     handler: async (req, res) => {
       const { title, description, date } = req.body;
       const { headers } = req;
+      const event = await axios.post(
+        `/events`,
+        {
+          title,
+          description,
+          date
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const event = await axios.post(
-          `/events`,
-          {
-            title,
-            description,
-            date
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(event.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(event.data);
     }
   },
   read: {
@@ -31,16 +26,11 @@ module.exports = {
     handler: async (req, res) => {
       const { eventId } = req.params;
       const { headers } = req;
+      const event = await axios.get(`/events/${eventId}`, {
+        headers
+      });
 
-      try {
-        const event = await axios.get(`/events/${eventId}`, {
-          headers
-        });
-
-        res.status(200).json(event.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(event.data);
     }
   },
   update: {
@@ -49,24 +39,19 @@ module.exports = {
       const { eventId } = req.params;
       const { title, description, date } = req.body;
       const { headers } = req;
+      const event = await axios.patch(
+        `/events/${eventId}`,
+        {
+          title,
+          description,
+          date
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const event = await axios.patch(
-          `/events/${eventId}`,
-          {
-            title,
-            description,
-            date
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(200).json(event.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(event.data);
     }
   },
   delete: {
@@ -74,20 +59,15 @@ module.exports = {
     handler: async (req, res) => {
       const { eventId } = req.params;
       const { headers } = req;
+      const event = await axios.delete(
+        `/events/${eventId}`,
+        {},
+        {
+          headers
+        }
+      );
 
-      try {
-        const event = await axios.delete(
-          `/events/${eventId}`,
-          {},
-          {
-            headers
-          }
-        );
-
-        res.status(200).json(event.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(event.data);
     }
   }
 };

--- a/src/server/api/eventsGames.js
+++ b/src/server/api/eventsGames.js
@@ -31,13 +31,5 @@ module.exports = {
 
       res.status(200).json(games.data);
     }
-  },
-  update: {
-    path: '/events/:eventId/games',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/events/:eventId/games',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/eventsGames.js
+++ b/src/server/api/eventsGames.js
@@ -7,22 +7,17 @@ module.exports = {
       const { eventId } = req.params;
       const { scores } = req.body;
       const { headers } = req;
+      const games = await axios.post(
+        `/events/${eventId}/games`,
+        {
+          scores
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const games = await axios.post(
-          `/events/${eventId}/games`,
-          {
-            scores
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(games.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(games.data);
     }
   },
   read: {
@@ -30,16 +25,11 @@ module.exports = {
     handler: async (req, res) => {
       const { eventId } = req.params;
       const { headers } = req;
+      const games = await axios.get(`/events/${eventId}/games`, {
+        headers
+      });
 
-      try {
-        const games = await axios.get(`/events/${eventId}/games`, {
-          headers
-        });
-
-        res.status(200).json(games.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(games.data);
     }
   },
   update: {

--- a/src/server/api/eventsMembers.js
+++ b/src/server/api/eventsMembers.js
@@ -32,13 +32,5 @@ module.exports = {
 
       res.status(200).json(members.data);
     }
-  },
-  update: {
-    path: '/events/:eventId/members',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/events/:eventId/members',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/eventsMembers.js
+++ b/src/server/api/eventsMembers.js
@@ -8,21 +8,17 @@ module.exports = {
       const { userIds } = req.body;
       const { headers } = req;
 
-      try {
-        const members = await axios.post(
-          `/events/${eventId}/members`,
-          {
-            user_ids: userIds
-          },
-          {
-            headers
-          }
-        );
+      const members = await axios.post(
+        `/events/${eventId}/members`,
+        {
+          user_ids: userIds
+        },
+        {
+          headers
+        }
+      );
 
-        res.status(201).json(members.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(members.data);
     }
   },
   read: {
@@ -30,16 +26,11 @@ module.exports = {
     handler: async (req, res) => {
       const { eventId } = req.params;
       const { headers } = req;
+      const members = await axios.get(`/events/${eventId}/members`, {
+        headers
+      });
 
-      try {
-        const members = await axios.get(`/events/${eventId}/members`, {
-          headers
-        });
-
-        res.status(200).json(members.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(members.data);
     }
   },
   update: {

--- a/src/server/api/groups.js
+++ b/src/server/api/groups.js
@@ -6,23 +6,18 @@ module.exports = {
     handler: async (req, res) => {
       const { name, description } = req.body;
       const { headers } = req;
+      const group = await axios.post(
+        `/groups`,
+        {
+          name,
+          description
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const group = await axios.post(
-          `/groups`,
-          {
-            name,
-            description
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(group.data);
     }
   },
   read: {
@@ -30,16 +25,11 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const group = await axios.get(`/groups/${groupId}`, {
+        headers
+      });
 
-      try {
-        const group = await axios.get(`/groups/${groupId}`, {
-          headers
-        });
-
-        res.status(200).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(group.data);
     }
   },
   update: {
@@ -48,23 +38,18 @@ module.exports = {
       const { groupId } = req.params;
       const { name, description } = req.body;
       const { headers } = req;
+      const group = await axios.patch(
+        `/groups/${groupId}`,
+        {
+          name,
+          description
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const group = await axios.patch(
-          `/groups/${groupId}`,
-          {
-            name,
-            description
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(group.data);
     }
   },
   delete: {
@@ -72,20 +57,15 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const group = await axios.delete(
+        `/groups/${groupId}`,
+        {},
+        {
+          headers
+        }
+      );
 
-      try {
-        const group = await axios.delete(
-          `/groups/${groupId}`,
-          {},
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(group.data);
     }
   }
 };

--- a/src/server/api/groupsEvents.js
+++ b/src/server/api/groupsEvents.js
@@ -7,24 +7,19 @@ module.exports = {
       const { groupId } = req.params;
       const { title, description, date } = req.body;
       const { headers } = req;
+      const event = await axios.post(
+        `/groups/${groupId}/events`,
+        {
+          title,
+          description,
+          date
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const event = await axios.post(
-          `/groups/${groupId}/events`,
-          {
-            title,
-            description,
-            date
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(event.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(event.data);
     }
   },
   read: {
@@ -32,16 +27,11 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const events = await axios.get(`/groups/${groupId}/events`, {
+        headers
+      });
 
-      try {
-        const events = await axios.get(`/groups/${groupId}/events`, {
-          headers
-        });
-
-        res.status(200).json(events.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(events.data);
     }
   },
   update: {

--- a/src/server/api/groupsEvents.js
+++ b/src/server/api/groupsEvents.js
@@ -33,13 +33,5 @@ module.exports = {
 
       res.status(200).json(events.data);
     }
-  },
-  update: {
-    path: '/groups/:groupId/events',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/groups/:groupId/events',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/groupsMembers.js
+++ b/src/server/api/groupsMembers.js
@@ -6,20 +6,15 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const group = await axios.post(
+        `/groups/${groupId}/members`,
+        {},
+        {
+          headers
+        }
+      );
 
-      try {
-        const group = await axios.post(
-          `/groups/${groupId}/members`,
-          {},
-          {
-            headers
-          }
-        );
-
-        res.status(201).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(group.data);
     }
   },
   read: {
@@ -27,16 +22,11 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const group = await axios.get(`/groups/${groupId}/members`, {
+        headers
+      });
 
-      try {
-        const group = await axios.get(`/groups/${groupId}/members`, {
-          headers
-        });
-
-        res.status(200).json(group.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(group.data);
     }
   },
   update: {

--- a/src/server/api/groupsMembers.js
+++ b/src/server/api/groupsMembers.js
@@ -28,13 +28,5 @@ module.exports = {
 
       res.status(200).json(group.data);
     }
-  },
-  update: {
-    path: '/groups/:groupId/members',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/groups/:groupId/members',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/groupsStats.js
+++ b/src/server/api/groupsStats.js
@@ -6,16 +6,11 @@ module.exports = {
     handler: async (req, res) => {
       const { groupId } = req.params;
       const { headers } = req;
+      const stats = await axios.get(`/groups/${groupId}/stats`, {
+        headers
+      });
 
-      try {
-        const stats = await axios.get(`/groups/${groupId}/stats`, {
-          headers
-        });
-
-        res.status(200).json(stats.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(stats.data);
     }
   }
 };

--- a/src/server/api/userToken.js
+++ b/src/server/api/userToken.js
@@ -19,17 +19,5 @@ module.exports = {
       });
       res.status(200).json({});
     }
-  },
-  read: {
-    path: '/user_token/*',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  update: {
-    path: '/user_token/*',
-    handler: async (req, res) => res.status(403).json({})
-  },
-  delete: {
-    path: '/user_token/*',
-    handler: async (req, res) => res.status(403).json({})
   }
 };

--- a/src/server/api/userToken.js
+++ b/src/server/api/userToken.js
@@ -5,24 +5,19 @@ module.exports = {
     path: '/user_token',
     handler: async (req, res) => {
       const { name, password } = req.body.auth;
+      const userToken = await axios.post(`/user_token`, {
+        auth: {
+          name,
+          password
+        }
+      });
 
-      try {
-        const userToken = await axios.post(`/user_token`, {
-          auth: {
-            name,
-            password
-          }
-        });
-
-        res.cookie('accessToken', userToken.data.jwt, {
-          axiosOnly: false,
-          maxAge: 1000 * 60 * 60 * 24,
-          secure: false // true
-        });
-        res.status(200).json({});
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.cookie('accessToken', userToken.data.jwt, {
+        axiosOnly: false,
+        maxAge: 1000 * 60 * 60 * 24,
+        secure: false // true
+      });
+      res.status(200).json({});
     }
   },
   read: {

--- a/src/server/api/users.js
+++ b/src/server/api/users.js
@@ -38,23 +38,18 @@ module.exports = {
       const { userId } = req.params;
       const { name, password } = req.body;
       const { headers } = req;
+      const users = await axios.patch(
+        `/users/${userId}`,
+        {
+          name,
+          password
+        },
+        {
+          headers
+        }
+      );
 
-      try {
-        const users = await axios.patch(
-          `/users/${userId}`,
-          {
-            name,
-            password
-          },
-          {
-            headers
-          }
-        );
-
-        res.status(200).json(users.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(users.data);
     }
   },
   delete: {
@@ -62,20 +57,15 @@ module.exports = {
     handler: async (req, res) => {
       const { userId } = req.params;
       const { headers } = req;
+      const user = await axios.delete(
+        `/users/${userId}`,
+        {},
+        {
+          headers
+        }
+      );
 
-      try {
-        const user = await axios.delete(
-          `/users/${userId}`,
-          {},
-          {
-            headers
-          }
-        );
-
-        res.status(200).json(user.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(user.data);
     }
   }
 };

--- a/src/server/api/users.js
+++ b/src/server/api/users.js
@@ -5,31 +5,21 @@ module.exports = {
     path: '/users',
     handler: async (req, res) => {
       const { name, password } = req.body;
+      const users = await axios.post(`/users`, {
+        name,
+        password
+      });
 
-      try {
-        const users = await axios.post(`/users`, {
-          name,
-          password
-        });
-
-        res.status(201).json(users.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(201).json(users.data);
     }
   },
   read: {
     path: '/users/:userId',
     handler: async (req, res) => {
       const { userId } = req.params;
+      const users = await axios.get(`/users/${userId}`);
 
-      try {
-        const users = await axios.get(`/users/${userId}`);
-
-        res.status(200).json(users.data);
-      } catch (e) {
-        res.status(404).json({});
-      }
+      res.status(200).json(users.data);
     }
   },
   update: {


### PR DESCRIPTION
@1000ch サーバーのエラーハンドリング直した。

- 各handlerの中でtry-catchせずにグローバルでハンドリングする
  - エラーメッセージをログに出力する
  - エラーコードは500を返す
  - 細かくエラーハンドリングしたい場合は各ハンドラーでメタ情報をのっけたerrorをthrowしてグローバルのハンドラーでハンドリングする必要がある
- 使ってないメソッド（403を返していたもの）を削除
  - 実装されてないrouteは404を返したいのでグローバルでrouteにマッチしないものを拾って404を返す